### PR TITLE
3.0.x

### DIFF
--- a/catalog/controller/extension/payment/iyzico_checkout_form.php
+++ b/catalog/controller/extension/payment/iyzico_checkout_form.php
@@ -401,7 +401,8 @@ $this->load->model('setting/extension');
                         }
    
                         if (!empty($items) && ($cart_total_amount != $sub_total)) {
-                            $last_item_index = end(array_keys($items));
+                            $item_array_keys = array_keys($items);
+                            $last_item_index = end($item_array_keys);
                             $last_item_object = $items[$last_item_index];
                             $item_price = $last_item_object->getPrice();
 

--- a/catalog/controller/extension/payment/iyzico_checkout_form.php
+++ b/catalog/controller/extension/payment/iyzico_checkout_form.php
@@ -387,7 +387,8 @@ $this->load->model('setting/extension');
 
                         
                         if (!empty($items) && ($sub_total != $product_prices)) {
-                                $last_item_index = end(array_keys($items));
+                                $item_array_keys = array_keys($items);
+                                $last_item_index = end($item_array_keys);
                                 $last_item_object = $items[$last_item_index];
                                 $item_price = $last_item_object->getPrice();
 


### PR DESCRIPTION
end() içerisinde array_keys kullanılamaz,

"The problem is, that end requires a reference, because it modifies the internal representation of the array (i.e. it makes the current element pointer point to the last element)."

bknz. https://stackoverflow.com/questions/4636166/only-variables-should-be-passed-by-reference